### PR TITLE
Add a badge for GitHub Actions to README.md and remove .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: php
-
-php:
-  - 5.4
-  - 5.5
-
-before_script: composer install
-
-script: ./vendor/bin/phpunit --colors ./tests/AllTests.php

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Test Status](https://github.com/pear/File_IMC/actions/workflows/ci.yml/badge.svg)](https://github.com/pear/File_IMC/actions/workflows/ci.yml)
+
 Allows you to programmatically create a vCard or vCalendar, and fetch the text.
 
 IMPORTANT: The array structure has changed slightly from Contact_Vcard_Parse.


### PR DESCRIPTION
This PR adds a badge for GitHub Actions to README.md and remove .travis.yml since .travis.yml is no longer needed as we have migrated to GitHub Actions due to the PR of #8.