### PR TITLE
Resolve "Result of method File_IMC_Parse::_convertLineEndings() (void) is used" detected by PHPStan

### DIFF
--- a/File/IMC/Parse.php
+++ b/File/IMC/Parse.php
@@ -160,7 +160,7 @@ abstract class File_IMC_Parse
     *
     * @param string $text The string on which to convert line endings.
     *
-    * @return void
+    * @return string|array
     */
     protected function _convertLineEndings($text)
     {


### PR DESCRIPTION
This PR resolves one error detected by PHPStan at level 0, changes the value of @return in File_IMC_Parse::_convertLineEndings() because the return type of the str_replace() is “string|array”.

ref: PHP: str_replace - Manual
https://www.php.net/manual/en/function.str-replace.php