### PR TITLE
Resolve "Result of method File_IMC_Build::validateParam() (void) is used" detected by PHPStan

### DIFF
--- a/File/IMC/Build.php
+++ b/File/IMC/Build.php
@@ -130,7 +130,7 @@ abstract class File_IMC_Build
     * @param string $iter Optional, the iteration of the property. Only
     * used for error messaging.
     *
-    * @return void
+    * @return mixed	      Boolean true if the parameter is valid
     * @throws File_IMC_Exception if not.
     */
     abstract function validateParam($name, $text, $prop = null, $iter = null);


### PR DESCRIPTION
This PR resolves one error detected by PHPStan at level 0, changes the value of the return type in File_IMC_Build:: validateParam() because the return type in File_IMC_Build_Vcard::validateParam() is “mixed”.